### PR TITLE
Add Optional alt Text Support for Project Components

### DIFF
--- a/src/components/project/ProjectImageBlock.tsx
+++ b/src/components/project/ProjectImageBlock.tsx
@@ -5,6 +5,7 @@ import ProjectImagesBlock from "src/components/project/ProjectImagesBlock";
 interface ProjectImage {
     src: string;
     caption?: string;
+    altText?: string;
 }
 
 interface ProjectImageBlockProps {

--- a/src/components/project/ProjectImageBlock.tsx
+++ b/src/components/project/ProjectImageBlock.tsx
@@ -5,7 +5,7 @@ import ProjectImagesBlock from "src/components/project/ProjectImagesBlock";
 interface ProjectImage {
     src: string;
     caption?: string;
-    altText?: string;
+    alt?: string;
 }
 
 interface ProjectImageBlockProps {

--- a/src/components/project/ProjectImagesBlock.tsx
+++ b/src/components/project/ProjectImagesBlock.tsx
@@ -10,7 +10,7 @@ import {
 interface ProjectImage {
     src: string;
     caption?: string;
-    altText?: string;
+    alt?: string;
 }
 
 interface ProjectImagesBlockProps {
@@ -62,7 +62,7 @@ export const ProjectImagesBlock: FunctionComponent<ProjectImagesBlockProps> = (p
                                                         maxHeight: (props.maxHeight === undefined) ? "400px" : props.maxHeight,
                                                         maxWidth: "100%"
                                                     }}
-                                                    alt={projectImage.altText ? `${projectImage.altText}` : 'Image that showcases the design process of the project.'}
+                                                    alt={projectImage.alt ? `${projectImage.alt}` : 'Image that showcases the design process of the project.'}
                                                 />
                                             </Paper>
                                             {

--- a/src/components/project/ProjectImagesBlock.tsx
+++ b/src/components/project/ProjectImagesBlock.tsx
@@ -62,7 +62,7 @@ export const ProjectImagesBlock: FunctionComponent<ProjectImagesBlockProps> = (p
                                                         maxHeight: (props.maxHeight === undefined) ? "400px" : props.maxHeight,
                                                         maxWidth: "100%"
                                                     }}
-                                                    alt={projectImage.alt ? `${projectImage.alt}` : 'Missing alt text.'}
+                                                    alt={projectImage.alt ? `${projectImage.alt}` : undefined}
                                                 />
                                             </Paper>
                                             {

--- a/src/components/project/ProjectImagesBlock.tsx
+++ b/src/components/project/ProjectImagesBlock.tsx
@@ -10,6 +10,7 @@ import {
 interface ProjectImage {
     src: string;
     caption?: string;
+    altText?: string;
 }
 
 interface ProjectImagesBlockProps {
@@ -61,6 +62,7 @@ export const ProjectImagesBlock: FunctionComponent<ProjectImagesBlockProps> = (p
                                                         maxHeight: (props.maxHeight === undefined) ? "400px" : props.maxHeight,
                                                         maxWidth: "100%"
                                                     }}
+                                                    alt={projectImage.altText ? `${projectImage.altText}` : 'Image that showcases the design process of the project.'}
                                                 />
                                             </Paper>
                                             {

--- a/src/components/project/TeamMemberGallery.tsx
+++ b/src/components/project/TeamMemberGallery.tsx
@@ -11,6 +11,7 @@ import {
 interface TeamMemberProps {
     name: string;
     photo: string;
+    altText?: string;
 }
 
 interface TeamMemberGalleryProps {
@@ -37,7 +38,7 @@ export const TeamMemberGallery: FunctionComponent<TeamMemberGalleryProps> = (pro
                                             <img
                                                 src={teamMemberProps.photo}
                                                 width="150"
-                                                alt={"Photo of " + teamMemberProps.name}
+                                                alt={`Photo of ${teamMemberProps.name}.${teamMemberProps.altText ? ` ${teamMemberProps.altText}` : '' }`}
                                             />
                                         </Stack>
                                     </CardContent>

--- a/src/components/project/TeamMemberGallery.tsx
+++ b/src/components/project/TeamMemberGallery.tsx
@@ -38,7 +38,7 @@ export const TeamMemberGallery: FunctionComponent<TeamMemberGalleryProps> = (pro
                                             <img
                                                 src={teamMemberProps.photo}
                                                 width="150"
-                                                alt={`Photo of ${teamMemberProps.name}.${teamMemberProps.alt ? ` ${teamMemberProps.alt}` : '' }`}
+                                                alt={teamMemberProps.alt ? teamMemberProps.alt : `Photo of ${teamMemberProps.name}.`}
                                             />
                                         </Stack>
                                     </CardContent>

--- a/src/components/project/TeamMemberGallery.tsx
+++ b/src/components/project/TeamMemberGallery.tsx
@@ -11,7 +11,7 @@ import {
 interface TeamMemberProps {
     name: string;
     photo: string;
-    altText?: string;
+    alt?: string;
 }
 
 interface TeamMemberGalleryProps {
@@ -38,7 +38,7 @@ export const TeamMemberGallery: FunctionComponent<TeamMemberGalleryProps> = (pro
                                             <img
                                                 src={teamMemberProps.photo}
                                                 width="150"
-                                                alt={`Photo of ${teamMemberProps.name}.${teamMemberProps.altText ? ` ${teamMemberProps.altText}` : '' }`}
+                                                alt={`Photo of ${teamMemberProps.name}.${teamMemberProps.alt ? ` ${teamMemberProps.alt}` : '' }`}
                                             />
                                         </Stack>
                                     </CardContent>


### PR DESCRIPTION
This pull request would provide for the opportunity to specify alt text for images in the `ProjectImageBlock`, `ProjectImagesBlock`, and `TeamMemberGallery` components. An optional `alt` parameter is added to all components relevant to this PR.

I know this is not related to the 4web assignment strictly, so I'm sorry for adding extra work for you! I have a friend who is legally blind (but not in 440 this quarter) and uses a screenreader, so I'm mostly doing this for her benefit.

Happy to make changes to address your feedback or feel free to make edits directly. Thank you for your time!

## Team member pictures
 In this case, it is used like this:
```jsx
<TeamMemberGallery members={[
    {
        name: "Winston",
        photo: imageTeamWinston,
        alt: "An adorable goldendoodle flopped on the ground, clearly not interested in project presentations."
    },
    // ...
]} />
```

This was also tested with and without the alt text. In the profile picture case, all of the <img> tags have a minimum of something like "Photo of Winston." as the alt text, and if someone specifies more, it will just be appended after.

## Project images
 In `ProjectImageBlock`, it is used like this:

```jsx
<ProjectImageBlock
     image={{
         src: imagePlaceholder1200x800,
         alt: "Right now it's just big grey X to show that it is taking up the space." // !!
     }}
     // ...
```

and in `ProjectImagesBlock`:
```jsx
<ProjectImagesBlock
    images={[
        {
            src: imagePlaceholder400x400,
            caption: "Bikes have two wheels.",
            alt: "This one has an image description"
        },
        {
            src: imagePlaceholder400x400,
            caption: "Airplane landing gears have a lot more wheels! :)",
            // alt: "this one does not, which is fine, because the parameter optional is in TypeScript"
        },
    ]}
    // [..]
```

In the project images case, the `alt` tag of `<img>` is not set if alt text is not supplied.
